### PR TITLE
fixing __environ in unset.c and export.c to work with mac os

### DIFF
--- a/inc/shell.h
+++ b/inc/shell.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   shell.h                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: vkuokka <vkuokka@student.hive.fi>          +#+  +:+       +#+        */
+/*   By: jochumwilen <jochumwilen@student.42.fr>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/01/05 19:57:45 by vkuokka           #+#    #+#             */
-/*   Updated: 2021/05/15 11:09:30 by vkuokka          ###   ########.fr       */
+/*   Updated: 2021/05/17 10:01:53 by jochumwilen      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,6 +29,16 @@
 # else
 #  include <limits.h>
 # endif
+
+# ifdef __APPLE__
+#  include <crt_externs.h>
+#  define environ (*_NSGetEnviron ())
+# else
+#  ifndef environ
+extern char **environ;
+#    endif
+#  endif
+
 
 # include "errors.h"
 

--- a/src/launcher/builtins/export.c
+++ b/src/launcher/builtins/export.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   export.c                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: vkuokka <vkuokka@student.hive.fi>          +#+  +:+       +#+        */
+/*   By: jochumwilen <jochumwilen@student.42.fr>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/05/14 17:37:49 by vkuokka           #+#    #+#             */
-/*   Updated: 2021/05/15 08:59:30 by vkuokka          ###   ########.fr       */
+/*   Updated: 2021/05/17 09:59:30 by jochumwilen      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,7 +25,7 @@ static void	export_variable(char *key, int print)
 		return ;
 	if (!setenv(key, value, 1) && print)
 		ft_printf("export %s=%s\n", key, value);
-	
+
 }
 
 static void	export_argument(char *data, int print)
@@ -63,6 +63,6 @@ int export_builtin(char **argv)
 			export_variable(argv[i], print);
 		i += 1;
 	}
-	g_shell->env = __environ;
+	g_shell->env = environ;
 	return (0);
 }

--- a/src/launcher/builtins/unset.c
+++ b/src/launcher/builtins/unset.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   unset.c                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: vkuokka <vkuokka@student.hive.fi>          +#+  +:+       +#+        */
+/*   By: jochumwilen <jochumwilen@student.42.fr>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/05/14 20:52:35 by vkuokka           #+#    #+#             */
-/*   Updated: 2021/05/15 09:56:56 by vkuokka          ###   ########.fr       */
+/*   Updated: 2021/05/17 09:59:57 by jochumwilen      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,6 +29,6 @@ int	unset_builtin(char **argv)
 		err += hash_delete(g_shell->vars, argv[i]);
 		i += 1;
 	}
-	g_shell->env = __environ;
+	g_shell->env = environ;
 	return (err);
 }


### PR DESCRIPTION
This is what makes the __enviroment work in Mac OS. Needs to be checked that it works also in linux with this changes.

information resources:
https://github.com/gcc-mirror/gcc/blob/master/include/environ.h
https://github.com/zeromq/czmq/issues/1834
man 7 environ   