### PR TITLE
Fixing the cd - path printout

### DIFF
--- a/src/launcher/builtins/cd.c
+++ b/src/launcher/builtins/cd.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   cd.c                                               :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: jwilen <jwilen@student.hive.fi>            +#+  +:+       +#+        */
+/*   By: jochumwilen <jochumwilen@student.42.fr>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/05/10 20:54:42 by vkuokka           #+#    #+#             */
-/*   Updated: 2021/05/29 14:47:53 by jwilen           ###   ########.fr       */
+/*   Updated: 2021/06/01 18:01:14 by jochumwilen      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -98,10 +98,10 @@ static int	move_to(char *path, int print)
 	pwd = getenv("PWD");
 	if (!chdir(path))
 	{
-		setenv("OLDPWD", pwd, 1);
-		setenv("PWD", path, 1);
 		if (print)
 			ft_putendl(path);
+		setenv("OLDPWD", pwd, 1);
+		setenv("PWD", path, 1);
 		return (0);
 	}
 	if (stat(path, &stats) == -1)


### PR DESCRIPTION
cd - gave out as print the current path before returning to the OLDPWD. Changed the order of print in function so that it prints out the folder it comes to when using cd -. This according to POSIX (which changes to the previous working directory and then writes its name.)