### PR TITLE
lexer fixes: recognize fd's in commands

### DIFF
--- a/src/lexer/token_control.c
+++ b/src/lexer/token_control.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   token_control.c                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: jwilen <jwilen@student.hive.fi>            +#+  +:+       +#+        */
+/*   By: srouhe <srouhe@student.hive.fi>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/03/31 12:04:06 by srouhe            #+#    #+#             */
-/*   Updated: 2021/07/15 18:39:11 by jwilen           ###   ########.fr       */
+/*   Updated: 2021/07/19 19:45:22 by srouhe           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,8 +29,11 @@ static int	create_token(t_lexer *lexer, char *input, char *operator, int i)
 	{
 		if (lexer->last && str_isnumeric(lexer->last->data))
 		{
-			input -= ft_strlen(operator) - 1;
-			ft_isdigit(*input) ? lexer->last->type |= IO_NUM : PASS;
+			if (i >= 4 && i <= 11)
+			{
+				lexer->last->type = 0;
+				lexer->last->type |= IO_NUM;
+			}
 		}
 		add_token(lexer, ft_strdup(operator), i);
 	}

--- a/src/lexer/token_string.c
+++ b/src/lexer/token_string.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   token_string.c                                     :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: jwilen <jwilen@student.hive.fi>            +#+  +:+       +#+        */
+/*   By: srouhe <srouhe@student.hive.fi>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/03/31 12:07:32 by srouhe            #+#    #+#             */
-/*   Updated: 2021/07/15 18:40:18 by jwilen           ###   ########.fr       */
+/*   Updated: 2021/07/19 19:44:24 by srouhe           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -47,16 +47,22 @@ static int	check_quoting(t_lexer *lexer, char *input, int i)
 
 static int	token_exceptions(t_lexer *lexer, char *input, int i)
 {
+	char *s;
+
+	s = ft_strsub(input, 0, i);
 	if (lexer->last && lexer->last->type & MASK_REDIR
 		&& !ft_strncmp(input, "-", 1))
 		add_token(lexer, ft_strsub(input, 0, i), DASH);
 	else if (lexer->last && lexer->last->type & T_DLARR)
 		add_token(lexer, ft_strsub(input, 0, i), HEREDOC);
+	else if (lexer->last && lexer->last->type & MASK_AG && str_isnumeric(s))
+		add_token(lexer, ft_strsub(input, 0, i), IO_NUMBER);
 	else if (lexer->last && lexer->last->type & MASK_REDIR
 		&& !(lexer->last->type & T_DLARR))
 		add_token(lexer, ft_strsub(input, 0, i), FILENAME);
 	else
 		add_token(lexer, ft_strsub(input, 0, i), STRING);
+	free(s);
 	return (i);
 }
 /*


### PR DESCRIPTION
"hieman" ruosteessa mut testailulla tunnistaa nyt fdt, esim 2> ja 2>&1, tosin oikee execution ei aina toimi, en tiiä onks se viel tekemättä execution -osassa. 