### PR TITLE
fix undefined behaviour, leaks

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   main.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: vkuokka <vkuokka@student.hive.fi>          +#+  +:+       +#+        */
+/*   By: sadawi <sadawi@student.hive.fi>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/01/05 19:47:31 by vkuokka           #+#    #+#             */
-/*   Updated: 2021/07/23 21:45:40 by vkuokka          ###   ########.fr       */
+/*   Updated: 2021/07/25 13:17:30 by sadawi           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -69,6 +69,7 @@ static void	shell(void)
 {
 	t_shell	shell;
 
+	ft_bzero(&shell, sizeof(shell));
 	shell.mode = isatty(STDIN_FILENO);
 	create_shell(&shell);
 	create_pgroup(&shell);
@@ -85,7 +86,7 @@ static void	shell(void)
 		reset(PROMPT_NORMAL, &shell);
 		editor(&shell);
 		if (shell.mode & ENDOFFILE)
-			break ;
+			exit(0) ;
 		else if (!shell.editor.buffer[0] || shell.mode & INTERRUPT)
 			continue ;
 		preprocess(shell.editor.buffer, &shell);


### PR DESCRIPTION
Leaks were caused due to ctrl + D leaving the `shell()` function, causing everything inside the variable `t_shell shell` to be leaked. Alternate fix would be to free everything properly, however exit also works fine.
```
==15084== HEAP SUMMARY:
==15084==     in use at exit: 1,598,694 bytes in 3,128 blocks
==15084==   total heap usage: 3,200 allocs, 72 frees, 2,002,146 bytes allocated
==15084== 
==15084== 6 bytes in 1 blocks are definitely lost in loss record 1 of 27
==15084==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==15084==    by 0x11ADAE: ft_strnew (ft_strnew.c:19)
==15084==    by 0x11A951: ft_strdup (ft_strdup.c:20)
==15084==    by 0x10AE8A: hash_put (hash.c:61)
==15084==    by 0x10B973: internal_alias (utils.c:83)
==15084==    by 0x10B9B2: create_shell (utils.c:90)
==15084==    by 0x10A992: shell (main.c:74)
==15084==    by 0x10AB3C: main (main.c:106)
==15084== 
==15084== 18 bytes in 1 blocks are definitely lost in loss record 6 of 27
==15084==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==15084==    by 0x11ADAE: ft_strnew (ft_strnew.c:19)
==15084==    by 0x11A951: ft_strdup (ft_strdup.c:20)
==15084==    by 0x10AEAD: hash_put (hash.c:62)
==15084==    by 0x10B973: internal_alias (utils.c:83)
==15084==    by 0x10B9B2: create_shell (utils.c:90)
==15084==    by 0x10A992: shell (main.c:74)
==15084==    by 0x10AB3C: main (main.c:106)
==15084== 
==15084== 444 bytes in 38 blocks are definitely lost in loss record 16 of 27
==15084==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==15084==    by 0x11ADAE: ft_strnew (ft_strnew.c:19)
==15084==    by 0x11A951: ft_strdup (ft_strdup.c:20)
==15084==    by 0x10AE8A: hash_put (hash.c:61)
==15084==    by 0x10B8FA: internal_variables (utils.c:75)
==15084==    by 0x10B9A0: create_shell (utils.c:89)
==15084==    by 0x10A992: shell (main.c:74)
==15084==    by 0x10AB3C: main (main.c:106)
==15084== 
==15084== 2,870 bytes in 38 blocks are definitely lost in loss record 21 of 27
==15084==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==15084==    by 0x11ADAE: ft_strnew (ft_strnew.c:19)
==15084==    by 0x11A951: ft_strdup (ft_strdup.c:20)
==15084==    by 0x10AEAD: hash_put (hash.c:62)
==15084==    by 0x10B8FA: internal_variables (utils.c:75)
==15084==    by 0x10B9A0: create_shell (utils.c:89)
==15084==    by 0x10A992: shell (main.c:74)
==15084==    by 0x10AB3C: main (main.c:106)
==15084== 
==15084== 1,575,600 (520 direct, 1,575,080 indirect) bytes in 1 blocks are definitely lost in loss record 27 of 27
==15084==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==15084==    by 0x11700F: ft_memalloc (ft_memalloc.c:19)
==15084==    by 0x10C6D2: autocomp_new_command (get_autocomplete_commands.c:41)
==15084==    by 0x10C720: autocomp_append_command (get_autocomplete_commands.c:50)
==15084==    by 0x10C815: autocomp_commands_append_dir (get_autocomplete_commands.c:75)
==15084==    by 0x10C896: autocomplete_from_path (get_autocomplete_commands.c:90)
==15084==    by 0x10C985: get_autocomplete_commands (get_autocomplete_commands.c:115)
==15084==    by 0x10A9F8: shell (main.c:85)
==15084==    by 0x10AB3C: main (main.c:106)
==15084== 
==15084== LEAK SUMMARY:
==15084==    definitely lost: 3,858 bytes in 79 blocks
==15084==    indirectly lost: 1,575,080 bytes in 3,029 blocks
==15084==      possibly lost: 0 bytes in 0 blocks
==15084==    still reachable: 19,756 bytes in 20 blocks
==15084==         suppressed: 0 bytes in 0 blocks
==15084== Reachable blocks (those to which a pointer was found) are not shown.
==15084== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==15084== 
==15084== For lists of detected and suppressed errors, rerun with: -s
==15084== ERROR SUMMARY: 5 errors from 5 contexts (suppressed: 0 from 0)
```

Undefined behaviour was caused by everything inside the struct `t_shell shell` being uninitialized. Initializing with 0 fixes that.
While I only found a problem with the `t_hash alias[]` variable, it makes sense to initialize everything with 0 to avoid any other variables possibly having similar problems.

```
==15695== Conditional jump or move depends on uninitialised value(s)
==15695==    at 0x11A9B5: ft_strequ (ft_strequ.c:19)
==15695==    by 0x10AFAE: hash_delete (hash.c:102)
==15695==    by 0x10ADF9: hash_put (hash.c:48)
==15695==    by 0x10B95F: internal_alias (utils.c:83)
==15695==    by 0x10B99E: create_shell (utils.c:90)
==15695==    by 0x10A97E: shell (main.c:73)
==15695==    by 0x10AB28: main (main.c:105)
==15695== 
==15695== Conditional jump or move depends on uninitialised value(s)
==15695==    at 0x10AE48: hash_put (hash.c:51)
==15695==    by 0x10B95F: internal_alias (utils.c:83)
==15695==    by 0x10B99E: create_shell (utils.c:90)
==15695==    by 0x10A97E: shell (main.c:73)
==15695==    by 0x10AB28: main (main.c:105)
==15695== 
command> ls
==15695== Conditional jump or move depends on uninitialised value(s)
==15695==    at 0x11A9B5: ft_strequ (ft_strequ.c:19)
==15695==    by 0x10AF14: hash_get (hash.c:79)
==15695==    by 0x115194: tokenize_alias (expand_alias.c:73)
==15695==    by 0x115A81: expand_tokens (expand.c:96)
==15695==    by 0x115C12: parser (index.c:40)
==15695==    by 0x10B2ED: preprocess (preprocess.c:74)
==15695==    by 0x10AA56: shell (main.c:91)
==15695==    by 0x10AB28: main (main.c:105)
==15695== 
42sh  author  inc  libft  Makefile  README.md  src  subjects  tests
command> 
```